### PR TITLE
chore: migrate from urfave/cli v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/gopasspw/gopass v1.16.1
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli/v2 v2.27.7
+	github.com/urfave/cli/v3 v3.9.0
 )
 
 require (
@@ -25,7 +25,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/gopasspw/clipboard v0.0.4 // indirect
 	github.com/gopasspw/gitconfig v0.0.3 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -34,6 +33,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/twpayne/go-pinentry/v4 v4.0.0 // indirect
+	github.com/urfave/cli/v2 v2.27.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/twpayne/go-pinentry/v4 v4.0.0 h1:8WcNa+UDVRzz7y9OEEU/nRMX+UGFPCAvl5Xs
 github.com/twpayne/go-pinentry/v4 v4.0.0/go.mod h1:aXvy+awVXqdH+GS0ddQ7AKHZ3tXM6fJ2NK+e16p47PI=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/urfave/cli/v3 v3.9.0 h1:AV9lIiPv3ukYnxunaCUsHnEozptYmDN2F0+yWqLMn/c=
+github.com/urfave/cli/v3 v3.9.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 
 	"github.com/gopasspw/gopass/pkg/gopass/api"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -47,18 +47,19 @@ func main() {
 		gp: gp,
 	}
 
-	app := cli.NewApp()
-	app.Name = name
-	app.Version = getVersion().String()
-	app.Usage = `Use "gopass-summon-provider" as provider for "summon"`
-	app.Description = "" +
-		"This command allows to use gopass as a secret provider for summon." +
-		"To use it set the 'SUMMON_PROVIDER' variable to this executable or" +
-		"copy or link it (as `gopass`) into the summon provider directory" +
-		"'/usr/local/lib/summon/'. See 'summon' documentation for more details."
-	app.Action = gc.Get
+	app := &cli.Command{
+		Name:    name,
+		Version: getVersion().String(),
+		Usage:   `Use "gopass-summon-provider" as provider for "summon"`,
+		Description: "" +
+			"This command allows to use gopass as a secret provider for summon." +
+			"To use it set the 'SUMMON_PROVIDER' variable to this executable or" +
+			"copy or link it (as `gopass`) into the summon provider directory" +
+			"'/usr/local/lib/summon/'. See 'summon' documentation for more details.",
+		Action: gc.Get,
+	}
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := app.Run(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/summon-provider.go
+++ b/summon-provider.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 // Stdout is exported for tests.
@@ -18,10 +19,9 @@ type gc struct {
 }
 
 // Get outputs the password for given path on stdout.
-func (s *gc) Get(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *gc) Get(ctx context.Context, cmd *cli.Command) error {
 	ctx = ctxutil.WithNoNetwork(ctx, true)
-	path := c.Args().Get(0)
+	path := cmd.Args().Get(0)
 	secret, err := s.gp.Get(ctx, path, "latest")
 	if err != nil {
 		return err

--- a/summon-provider_test.go
+++ b/summon-provider_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass/pkg/gopass/apimock"
 	"github.com/gopasspw/gopass/pkg/termio"
-	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
 
 func TestSummonProviderOutputsOnlySecret(t *testing.T) { //nolint:paralleltest
@@ -28,6 +28,9 @@ func TestSummonProviderOutputsOnlySecret(t *testing.T) { //nolint:paralleltest
 		Stdout = os.Stdout
 	}()
 
-	require.NoError(t, act.Get(gptest.CliCtx(ctx, t, "foo")))
+	app := &cli.Command{
+		Action: act.Get,
+	}
+	require.NoError(t, app.Run(ctx, []string{"app", "foo"}))
 	assert.Equal(t, "bar\n", buf.String())
 }


### PR DESCRIPTION
- Replace github.com/urfave/cli/v2 import with github.com/urfave/cli/v3
- Replace cli.NewApp() with &cli.Command{} struct literal (App type removed in v3)
- Replace app.RunContext(ctx, args) with app.Run(ctx, args)
- Update ActionFunc signature: func(*cli.Context) error -> func(context.Context, *cli.Command) error
- Remove ctxutil.WithGlobalFlags (context now passed directly to action)
- Update test to use cli.Command.Run instead of gptest.CliCtx